### PR TITLE
cpu.c: Add missing M_MAIN feature set for M4F

### DIFF
--- a/target/arm/cpu.c
+++ b/target/arm/cpu.c
@@ -1495,6 +1495,7 @@ static void cortex_m4f_initfn(Object *obj)
 
     set_feature(&cpu->env, ARM_FEATURE_V7);
     set_feature(&cpu->env, ARM_FEATURE_M);
+    set_feature(&cpu->env, ARM_FEATURE_M_MAIN);
     set_feature(&cpu->env, ARM_FEATURE_THUMB_DSP);
     set_feature(&cpu->env, ARM_FEATURE_VFP4);
     cpu->midr = 0x410fc240; /* r0p0 */


### PR DESCRIPTION
This feature set adds missing capabilities that are supposed to exist in M4 chips such as unaligned accesses.