### PR TITLE
cpu.c: Add missing M_MAIN feature flag

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -3263,7 +3263,6 @@ static MemTxResult flatview_write_continue(FlatView *fv, hwaddr addr,
                                            hwaddr l, MemoryRegion *mr)
 {
     uint8_t *ptr;
-    uint64_t val;
     MemTxResult result = MEMTX_OK;
     bool release_lock = false;
 
@@ -3273,8 +3272,7 @@ static MemTxResult flatview_write_continue(FlatView *fv, hwaddr addr,
             l = memory_access_size(mr, l, addr1);
             /* XXX: could force current_cpu to NULL to avoid
                potential bugs */
-            val = ldn_p(buf, l);
-            result |= memory_region_dispatch_write(mr, addr1, val, l, attrs);
+            result |= memory_region_dispatch_writeb(mr, addr1, buf, l, attrs);
         } else {
             /* RAM case */
             ptr = qemu_ram_ptr_length(mr->ram_block, addr1, &l, false);
@@ -3326,7 +3324,6 @@ MemTxResult flatview_read_continue(FlatView *fv, hwaddr addr,
                                    MemoryRegion *mr)
 {
     uint8_t *ptr;
-    uint64_t val;
     MemTxResult result = MEMTX_OK;
     bool release_lock = false;
 
@@ -3335,8 +3332,7 @@ MemTxResult flatview_read_continue(FlatView *fv, hwaddr addr,
             /* I/O case */
             release_lock |= prepare_mmio_access(mr);
             l = memory_access_size(mr, l, addr1);
-            result |= memory_region_dispatch_read(mr, addr1, &val, l, attrs);
-            stn_p(buf, l, val);
+            result |= memory_region_dispatch_readb(mr, addr1, buf, l, attrs);
         } else {
             /* RAM case */
             ptr = qemu_ram_ptr_length(mr->ram_block, addr1, &l, false);

--- a/hw/block/nand.c
+++ b/hw/block/nand.c
@@ -1130,6 +1130,7 @@ static void glue(nand_init_, PAGE_SIZE)(NANDFlashState *s)
 {
     s->oob_shift = PAGE_SHIFT - 5;
     __oob_shift = s->oob_shift;
+    __oob_size = (1 << __oob_shift);
     if (s->buswidth == 2) { // 16 bit
         s->oob_shift++;
         __oob_shift++;

--- a/hw/block/nand.c
+++ b/hw/block/nand.c
@@ -55,7 +55,7 @@
 # define NAND_IOSTATUS_UNPROTCT	(1 << 7)
 
 # define MAX_PAGE		0x800
-# define MAX_OOB		0x40
+# define MAX_OOB		0x80
 # define MAX_PARM_PAGE_SIZE     256
 # define MAX_EXT_PARM_PAGE_SIZE 48
 
@@ -67,6 +67,8 @@ struct NANDFlashState {
     MemoryRegion iomem;
 
     uint8_t manf_id, chip_id;
+    uint32_t full_id_low;
+    uint32_t full_id_high;
     uint8_t buswidth; /* in BYTES */
     uint64_t size;
     int  pages;
@@ -131,11 +133,12 @@ static void mem_and(uint8_t *dest, const uint8_t *src, size_t n)
 # define NAND_IO
 
 # define PAGE(addr)		((addr) >> PAGE_SHIFT)
-# define PAGE_START(page)	(PAGE(page) * (PAGE_SIZE + OOB_SIZE))
+# define PAGE_START(page)	(PAGE(page) * (PAGE_SIZE + __oob_size))
 # define PAGE_MASK		((1 << PAGE_SHIFT) - 1)
 
-# define OOB_SHIFT		(PAGE_SHIFT - 5)
-# define OOB_SIZE		(1 << OOB_SHIFT)
+static int __oob_shift = 0;
+static int __oob_size = 0;
+
 # define SECTOR(addr)		((addr) >> (9 + ADDR_SHIFT - PAGE_SHIFT))
 # define SECTOR_OFFSET(addr)	((addr) & ((511 >> PAGE_SHIFT) << 8))
 
@@ -436,16 +439,23 @@ static void nand_command(NANDFlashState *s)
         s->iolen = 0;
         s->reglen = 0;
         s->regaddr = s->reg_data;
-        nand_pushio_byte(s, s->manf_id, true);
-        nand_pushio_byte(s, s->chip_id, true);
-        nand_pushio_byte(s, 'Q', true); /* Don't-care byte (often 0xa5) */
-        if (nand_flash_ids[s->chip_id].options & NAND_SAMSUNG_LP) {
-            /* Page Size, Block Size, Spare Size; bit 6 indicates
-             * 8 vs 16 bit width NAND.
-             */
-            nand_pushio_byte(s, (s->buswidth == 2) ? 0x55 : 0x15, true);
+        if (s->full_id_low != 0) {
+            for (i=0; i < 4; i++)
+               nand_pushio_byte(s, (s->full_id_low >> (i << 3)) & 0xff, true);
+            for (i=0; i < 4; i++)
+               nand_pushio_byte(s, (s->full_id_high >> (i << 3)) & 0xff, true);
         } else {
-            nand_pushio_byte(s, 0xc0, true); /* Multi-plane */
+           nand_pushio_byte(s, s->manf_id, true);
+           nand_pushio_byte(s, s->chip_id, true);
+           nand_pushio_byte(s, 'Q', true); /* Don't-care byte (often 0xa5) */
+           if (nand_flash_ids[s->chip_id].options & NAND_SAMSUNG_LP) {
+               /* Page Size, Block Size, Spare Size; bit 6 indicates
+                * 8 vs 16 bit width NAND.
+                */
+               nand_pushio_byte(s, (s->buswidth == 2) ? 0x55 : 0x15, true);
+           } else {
+               nand_pushio_byte(s, 0xc0, true); /* Multi-plane */
+            }
         }
         break;
     case NAND_CMD_READ_PARAMETER_PAGE:
@@ -684,6 +694,8 @@ static Property nand_properties[] = {
     DEFINE_PROP_UINT32("start_addr_high", NANDFlashState, start_addr_high, 0),
     DEFINE_PROP_UINT32("start_addr_low", NANDFlashState, start_addr_low, 0),
     DEFINE_PROP_UINT32("rank", NANDFlashState, rank, 0),
+    DEFINE_PROP_UINT32("full_id_low", NANDFlashState, full_id_low, 0),
+    DEFINE_PROP_UINT32("full_id_high", NANDFlashState, full_id_high, 0),
     DEFINE_PROP_END_OF_LIST(),
 };
 
@@ -720,12 +732,6 @@ uint32_t nand_iolen(DeviceState * opaque)
 {
    NANDFlashState *s = NAND(opaque);
    return s->iolen;
-}
-
-uint32_t nand_buswidth(DeviceState * opaque)
-{
-   NANDFlashState *s = NAND(opaque);
-   return s->buswidth;
 }
 
 /*
@@ -989,8 +995,8 @@ static void glue(nand_blk_write_, PAGE_SIZE)(NANDFlashState *s)
         mem_and(iobuf + (soff | off), s->io, MIN(s->iolen, PAGE_SIZE - off));
         if (off + s->iolen > PAGE_SIZE) {
             page = PAGE(s->addr);
-            mem_and(s->storage + (page << OOB_SHIFT), s->io + PAGE_SIZE - off,
-                            MIN(OOB_SIZE, off + s->iolen - PAGE_SIZE));
+            mem_and(s->storage + (page << __oob_shift), s->io + PAGE_SIZE - off,
+                            MIN(__oob_size, off + s->iolen - PAGE_SIZE));
         }
 
         if (blk_pwrite(s->blk, sector << BDRV_SECTOR_BITS, iobuf,
@@ -1037,10 +1043,10 @@ static void glue(nand_blk_erase_, PAGE_SIZE)(NANDFlashState *s)
 
     if (!s->blk) {
         memset(s->storage + PAGE_START(addr),
-                        0xff, (PAGE_SIZE + OOB_SIZE) << s->erase_shift);
+                        0xff, (PAGE_SIZE + __oob_size) << s->erase_shift);
     } else if (s->mem_oob) {
-        memset(s->storage + (PAGE(addr) << OOB_SHIFT),
-                        0xff, OOB_SIZE << s->erase_shift);
+        memset(s->storage + (PAGE(addr) << __oob_shift),
+                        0xff, __oob_size << s->erase_shift);
         i = SECTOR(addr);
         page = SECTOR(addr + (1 << (ADDR_SHIFT + s->erase_shift)));
         for (; i < page; i ++)
@@ -1063,7 +1069,7 @@ static void glue(nand_blk_erase_, PAGE_SIZE)(NANDFlashState *s)
 
         memset(iobuf, 0xff, 0x200);
         i = (addr & ~0x1ff) + 0x200;
-        for (addr += ((PAGE_SIZE + OOB_SIZE) << s->erase_shift) - 0x200;
+        for (addr += ((PAGE_SIZE + __oob_size) << s->erase_shift) - 0x200;
                         i < addr; i += 0x200) {
             if (blk_pwrite(s->blk, i, iobuf, BDRV_SECTOR_SIZE, 0) < 0) {
                 printf("%s: write error in sector %" PRIu64 "\n",
@@ -1101,8 +1107,8 @@ static void glue(nand_blk_load_, PAGE_SIZE)(NANDFlashState *s,
                                 __func__, SECTOR(addr));
             }
             memcpy(s->io + SECTOR_OFFSET(s->addr) + PAGE_SIZE,
-                            s->storage + (PAGE(s->addr) << OOB_SHIFT),
-                            OOB_SIZE);
+                            s->storage + (PAGE(s->addr) << __oob_shift),
+                            __oob_size);
             s->ioaddr = s->io + SECTOR_OFFSET(s->addr) + offset;
         } else {
             /* blk_pread: reads data from PAGE_START(addr) */
@@ -1115,7 +1121,7 @@ static void glue(nand_blk_load_, PAGE_SIZE)(NANDFlashState *s,
         }
     } else {
         memcpy(s->io, s->storage + PAGE_START(s->addr) +
-                        offset, PAGE_SIZE + OOB_SIZE - offset);
+                        offset, PAGE_SIZE + __oob_size - offset);
         s->ioaddr = s->io;
     }
 }
@@ -1123,6 +1129,12 @@ static void glue(nand_blk_load_, PAGE_SIZE)(NANDFlashState *s,
 static void glue(nand_init_, PAGE_SIZE)(NANDFlashState *s)
 {
     s->oob_shift = PAGE_SHIFT - 5;
+    __oob_shift = s->oob_shift;
+    if (s->buswidth == 2) { // 16 bit
+        s->oob_shift++;
+        __oob_shift++;
+        __oob_size = (1 << __oob_shift);
+    }
     s->pages = s->size >> PAGE_SHIFT;
     s->addr_shift = ADDR_SHIFT;
 

--- a/hw/core/sysbus.c
+++ b/hw/core/sysbus.c
@@ -324,6 +324,7 @@ MemoryRegion *sysbus_address_space(SysBusDevice *dev)
 static bool sysbus_parse_reg(FDTGenericMMap *obj, FDTGenericRegPropInfo reg,
                              Error **errp) {
     int i;
+    MemoryRegion *dev_mr;
 
     for (i = 0; i < reg.n; ++i) {
         MemoryRegion *mr_parent = (MemoryRegion *)
@@ -332,9 +333,10 @@ static bool sysbus_parse_reg(FDTGenericMMap *obj, FDTGenericRegPropInfo reg,
             /* evil */
             mr_parent = get_system_memory();
         }
+        dev_mr = sysbus_mmio_get_region(SYS_BUS_DEVICE(obj), i);
+        memory_region_set_size(dev_mr, reg.s[i]);
         memory_region_add_subregion_overlap(mr_parent, reg.a[i],
-                    sysbus_mmio_get_region(SYS_BUS_DEVICE(obj), i),
-                    reg.p[i]);
+                dev_mr, reg.p[i]);
     }
     return false;
 }

--- a/hw/intc/arm_gicv3_common.c
+++ b/hw/intc/arm_gicv3_common.c
@@ -360,6 +360,31 @@ static int arm_gicv3_common_fdt_get_irq(FDTGenericIntc *obj, qemu_irq *irqs,
     }
 }
 
+static void arm_gicv3_common_init(Object *obj)
+{
+    GICv3State *s = ARM_GICV3_COMMON(obj);
+    Error *errp = NULL;
+    int i;
+    char *prop_name;
+
+    /* Bind to device tree properties, values will be available on realize */
+    for (i = 0; i < GICV3_MAXCPUS; i++) {
+        prop_name = g_strdup_printf("cpu%d", i);
+        object_property_add_link(obj, prop_name, TYPE_CPU,
+                                 (Object **)&s->cpu_handles[i],
+                                 qdev_prop_allow_set_link_before_realize,
+                                 OBJ_PROP_LINK_STRONG,
+                                 &errp);
+        if (errp) {
+            error_prepend(&errp, "failed bind cpu handle to prop '%s'",
+                          prop_name);
+            g_free(prop_name);
+            error_propagate(&error_fatal, errp); /* exits process */
+        }
+        g_free(prop_name);
+    }
+}
+
 static void arm_gicv3_common_realize(DeviceState *dev, Error **errp)
 {
     GICv3State *s = ARM_GICV3_COMMON(dev);
@@ -403,9 +428,14 @@ static void arm_gicv3_common_realize(DeviceState *dev, Error **errp)
     s->cpu = g_new0(GICv3CPUState, s->num_cpu);
 
     for (i = 0; i < s->num_cpu; i++) {
-        CPUState *cpu = qemu_get_cpu(s->cpu_start_id + i);
         uint64_t cpu_affid;
         int last;
+        CPUState *cpu = s->cpu_handles[i];
+
+        if (!cpu) {
+            error_setg(errp, "'cpu%u' prop not set to a CPU handle", i);
+            return;
+        }
 
         s->cpu[i].cpu = cpu;
         s->cpu[i].gic = s;
@@ -560,7 +590,6 @@ static Property arm_gicv3_common_properties[] = {
     DEFINE_PROP_BOOL("has-security-extensions", GICv3State, security_extn, 0),
     DEFINE_PROP_ARRAY("redist-region-count", GICv3State, nb_redist_regions,
                       redist_region_count, qdev_prop_uint32, uint32_t),
-    DEFINE_PROP_UINT32("cpu-start-id", GICv3State, cpu_start_id, 0),
     DEFINE_PROP_UINT32("gicd-typer", GICv3State, gicd_typer, 0),
     DEFINE_PROP_END_OF_LIST(),
 };
@@ -585,6 +614,7 @@ static const TypeInfo arm_gicv3_common_type = {
     .instance_size = sizeof(GICv3State),
     .class_size = sizeof(ARMGICv3CommonClass),
     .class_init = arm_gicv3_common_class_init,
+    .instance_init = arm_gicv3_common_init,
     .instance_finalize = arm_gicv3_finalize,
     .abstract = true,
     .interfaces = (InterfaceInfo []) {

--- a/hw/intc/arm_gicv3_cpuif.c
+++ b/hw/intc/arm_gicv3_cpuif.c
@@ -2876,8 +2876,8 @@ void gicv3_init_cpuif(GICv3State *s)
     int i;
 
     for (i = 0; i < s->num_cpu; i++) {
-        ARMCPU *cpu = ARM_CPU(qemu_get_cpu(s->cpu_start_id + i));
         GICv3CPUState *cs = &s->cpu[i];
+        ARMCPU *cpu = ARM_CPU(cs->cpu);
 
         /* fixup for GICR_TYPER of R52 */
         if (arm_feature(&cpu->env, ARM_FEATURE_V8R)) {

--- a/hw/intc/gicv3_internal.h
+++ b/hw/intc/gicv3_internal.h
@@ -51,7 +51,7 @@
 #define GICD_SGIR            0x0F00
 #define GICD_CPENDSGIR       0x0F10
 #define GICD_SPENDSGIR       0x0F20
-#define GICD_IROUTER         0x6000
+#define GICD_IROUTER         0x6100
 #define GICD_IDREGS          0xFFD0
 
 /* GICD_CTLR fields  */

--- a/include/exec/memory.h
+++ b/include/exec/memory.h
@@ -170,6 +170,17 @@ struct MemoryRegionOps {
                                     unsigned size,
                                     MemTxAttrs attrs);
 
+    MemTxResult (*readb_with_attrs)(void *opaque,
+                                   hwaddr addr,
+                                   uint8_t *data,
+                                   unsigned size,
+                                   MemTxAttrs attrs);
+    MemTxResult (*writeb_with_attrs)(void *opaque,
+                                    hwaddr addr,
+                                    const uint8_t *data,
+                                    unsigned size,
+                                    MemTxAttrs attrs);
+
     enum device_endian endianness;
     /* Guest-visible constraints: */
     struct {
@@ -1747,6 +1758,21 @@ MemTxResult memory_region_dispatch_read(MemoryRegion *mr,
                                         unsigned size,
                                         MemTxAttrs attrs);
 /**
+ * memory_region_dispatch_readb: read a sequence of bytes directly from the
+ * specified MemoryRegion.
+ *
+ * @mr: #MemoryRegion to access
+ * @addr: address within that region
+ * @data: pointer to the destination buffer to which to write the data
+ * @size: size of the access in bytes
+ * @attrs: memory transaction attributes to use for the access
+ */
+MemTxResult memory_region_dispatch_readb(MemoryRegion *mr,
+                                         hwaddr addr,
+                                         uint8_t *data,
+                                         unsigned size,
+                                         MemTxAttrs attrs);
+/**
  * memory_region_dispatch_write: perform a write directly to the specified
  * MemoryRegion.
  *
@@ -1761,6 +1787,21 @@ MemTxResult memory_region_dispatch_write(MemoryRegion *mr,
                                          uint64_t data,
                                          unsigned size,
                                          MemTxAttrs attrs);
+/**
+ * memory_region_dispatch_writeb: write a sequence of bytes directly to the
+ * the specified MemoryRegion.
+ *
+ * @mr: #MemoryRegion to access
+ * @addr: address within that region
+ * @data: pointer to the bytes to write
+ * @size: size of the access in bytes
+ * @attrs: memory transaction attributes to use for the access
+ */
+MemTxResult memory_region_dispatch_writeb(MemoryRegion *mr,
+                                          hwaddr addr,
+                                          const uint8_t *data,
+                                          unsigned size,
+                                          MemTxAttrs attrs);
 
 /**
  * address_space_init: initializes an address space

--- a/include/hw/block/flash.h
+++ b/include/hw/block/flash.h
@@ -56,7 +56,7 @@ uint32_t nand_getio(DeviceState *dev);
 uint32_t nand_getbuswidth(DeviceState *dev);
 uint32_t nand_page_size(DeviceState *dev);
 uint32_t nand_iolen(DeviceState *dev);
-uint32_t nand_buswidth(DeviceState * opaque);
+void nand_init_ops(DeviceState *dev, const MemoryRegionOps* ops);
 
 #define NAND_MFR_TOSHIBA	0x98
 #define NAND_MFR_SAMSUNG	0xec

--- a/target/arm/cpu.c
+++ b/target/arm/cpu.c
@@ -1616,6 +1616,7 @@ static void cortex_m4f_initfn(Object *obj)
 
     set_feature(&cpu->env, ARM_FEATURE_V7);
     set_feature(&cpu->env, ARM_FEATURE_M);
+    set_feature(&cpu->env, ARM_FEATURE_M_MAIN);
     set_feature(&cpu->env, ARM_FEATURE_THUMB_DSP);
     set_feature(&cpu->env, ARM_FEATURE_VFP4);
     cpu->midr = 0x410fc241; /* ARM Cortex-M4 r0p1 */


### PR DESCRIPTION
This adds a set of features expected to exist in M4 CPUs including capabilities such as unaligned accesses.